### PR TITLE
Simplify travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,10 @@
 language: python
 python:
-  - 2.7
-  - 3.4
-notifications:
-  email: false
-
-before_install:
-  # Setup Miniconda - a lightweight anaconda
-  # This allows us to get pre-build binaries from numpy etc. from binstar
-  # This is quicker and more reliable than compiling from source every build
-  # See  https://gist.githubusercontent.com/dan-blanchard/7045057/raw/8ca5a4abcd0c65ab05217dd92119001f8454c369/.travis.yml
-  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update --yes conda
-
+  - "2.7"
+  - "3.4"
+  - "3.6"
 install:
-  # Download numpy and matplotlib binaries from binstar
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy pandas
-  # Setup coverage for converage measurement
-  - pip install coverage
-  
+  - pip install -r requirements.txt
   - python setup.py install
-
-
 script:
-  # Run tests
-  - coverage run --source=multihist setup.py test
-
-after_success:
-  # Calculate coverage
-  - coveralls
+  - python setup.py test


### PR DESCRIPTION
This simplifies the travis settings, removing miniconda in favor of the default travis python.