### PR TITLE
Feldman-Cousins errors for Hist1d.plot

### DIFF
--- a/multihist.py
+++ b/multihist.py
@@ -280,8 +280,8 @@ class Hist1d(MultiHistBase):
                 if 'alpha' in kwargs:
                     alpha *= kwargs['alpha']
                     del kwargs['alpha']
+                kwargs['linewidth'] = 0
                 plt.fill_between(x, ylow, yhigh,
-                                 linewidth=0,
                                  alpha=alpha,
                                  step='pre', **kwargs)
             else:

--- a/multihist.py
+++ b/multihist.py
@@ -281,6 +281,9 @@ class Hist1d(MultiHistBase):
                     alpha *= kwargs['alpha']
                     del kwargs['alpha']
                 kwargs['linewidth'] = 0
+                if 'label' in kwargs:
+                    # Don't want to double-label!
+                    del kwargs['label']
                 plt.fill_between(x, ylow, yhigh,
                                  alpha=alpha,
                                  step='pre', **kwargs)

--- a/multihist.py
+++ b/multihist.py
@@ -212,7 +212,7 @@ class Hist1d(MultiHistBase):
 
     def plot(self,
              normed=False, scale_histogram_by=1.0, scale_errors_by=1.0,
-             errors=False, errorstyle='bar', error_alpha=0.3,
+             errors=False, error_style='bar', error_alpha=0.3,
              plt=plt, set_xlim=False,
              **kwargs):
         """Plot the histogram, with error bars if desired.
@@ -256,7 +256,7 @@ class Hist1d(MultiHistBase):
         ylow = ylow.astype(np.float) * scale_histogram_by * scale_errors_by
         yhigh = yhigh.astype(np.float) * scale_histogram_by * scale_errors_by
 
-        if errors and errorstyle == 'bar':
+        if errors and error_style == 'bar':
             kwargs.setdefault('linestyle', 'none')
             kwargs.setdefault('marker', '.')
             plt.errorbar(self.bin_centers,
@@ -274,7 +274,7 @@ class Hist1d(MultiHistBase):
             ylow = fix(ylow)
             yhigh = fix(yhigh)
 
-            if errors and errorstyle == 'band':
+            if errors and error_style == 'band':
                 plt.plot(x, y, drawstyle='steps-pre', **kwargs)
                 alpha = error_alpha
                 if 'alpha' in kwargs:


### PR DESCRIPTION
This changes Hist1d.plot to plot 1 sigma Feldman-Cousins confidence intervals (b=0) for a Poisson distribution, rather than sqrt(N) errors. You can switch back to sqrt(N) errors, or use ordinary two-sided poisson intervals. By default errors are not plotted; you have to set the `errors` argument to something.

Example:
```python
import numpy as np
import matplotlib.pyplot as plt
from multihist import Hist1d

x, y = np.arange(11), np.arange(10)

for i, errors in enumerate(['fc', 'central', 'sqrtn']):
    
    Hist1d.from_histogram(y, bin_edges=x + 0.15 * i).plot(
        errors=errors, label=errors)

plt.legend(loc='upper left')
plt.xlim(0, 10)
```
![multihist_errors](https://user-images.githubusercontent.com/4354311/72814169-e2f00b80-3c64-11ea-95d6-df9dc613094d.png)


Additionally, this adds a new `error_style='band'` option to make a shaded-band error plot.  Also note `set_xlim=True` for those who do not want to write out `plt.xlim(h.bin_edges[0], h.bin_edges[-1])`:
```python
h = Hist1d.from_histogram(y, bin_edges=x)
h.plot(
    errors=True, error_style='band', set_xlim=True)
```
![multihist_errors_band](https://user-images.githubusercontent.com/4354311/72814494-6a3d7f00-3c65-11ea-8b19-2b53783b9e15.png)
