### PR TITLE
New slice function of Histdd to support binning fragment

### DIFF
--- a/multihist.py
+++ b/multihist.py
@@ -584,7 +584,7 @@ class Histdd(MultiHistBase):
 
         return Histdd.from_histogram(new_hist, bin_edges=new_bin_edges, axis_names=self.axis_names)        
 
-    def slicesum(self, start, stop=None, axis=0):
+    def slicesum(self, start, stop, axis):
         """Slices the histogram along axis, then sums over that slice, returning a d-1 dimensional histogram"""
         return self.slice(start, stop, axis).sum(axis)
 


### PR DESCRIPTION
This PR modifies the function `Histdd.slice`, to let it support binning fragment when the `start` or `stop` are not exactly at the bin edges. The fragments are calculated by multiplying the original histogram by the bin volume inclusion fraction.

For example, 
![Screenshot 2024-10-29 at 9 12 24 PM](https://github.com/user-attachments/assets/de0f1ba6-76ce-4ad0-9ab6-49b8d83817d0)
is from the the following code
```
from multihist import Histdd
import numpy as np
import matplotlib.pyplot as plt

sample_size = int(1e6)

x = np.random.uniform(0, 1, sample_size)
r = np.sqrt(np.random.uniform(0, 100, sample_size))
hist = Histdd(x, r, bins=[np.linspace(0, 1, 30), np.linspace(0, 10, 11)], axis_names=['x', 'r'])

hist.project(axis=1).plot(label='Full hisotgram')
hist.slice(3.2, 7.6, axis=1).project(axis='r').plot(label='Sliced histogram from 3.2 to 7.6')
hist.slice(-2, -0.5, axis=1).project(axis='r').plot(label='Sliced histogram from -2 to -0.5')
hist.slice(8.4, 12, axis=1).project(axis='r').plot(label='Sliced histogram from 8.4 to 12')

plt.legend()
plt.show()
```